### PR TITLE
Add table kvk bronhouder

### DIFF
--- a/brodata/bro.py
+++ b/brodata/bro.py
@@ -640,3 +640,57 @@ def get_brondocumenten_per_bronhouder(index=("kvk", "type"), timeout=5, **kwargs
             index = list(index)
         df = df.set_index(index)
     return df
+
+
+def dataframe_kvk(fn_bronhouder_kvk=None):
+    """
+    Read manually saved table of KVK and Organisatienaam to DataFrame.
+
+    from https://basisregistratieondergrond.nl/service-contact/formulieren/aangemeld-bro/
+    :param fn_bronhouder_kvk: str, filename of the file with bronhouder and kvk numbers
+    :return: pandas DataFrame with kvk as index and column 'Organisatienaam' and 'Bronhouder'
+    """
+    if fn_bronhouder_kvk is None:
+        fn_bronhouder_kvk = os.path.join(
+            os.path.dirname(__file__), "data", "bronhouder_kvk.txt"
+        )
+
+    df_bron_kvk = pd.read_csv(
+        fn_bronhouder_kvk,
+        sep=";",  # is a dummy value, data will be split later on the last | sign
+        dtype=str,
+        header=None,
+        names=["all_data"],
+        skipinitialspace=True,
+        comment="#",
+    )
+
+    # split column all_data into bronhouder and kvk, using last | sign; both as string type
+    # mind that index has string type, as that is format provided in brodata downloads
+    df_bron_kvk[["Organisatienaam", "KVK-nummer"]] = (
+        df_bron_kvk["all_data"].str.rsplit("|", n=1, expand=True).astype(str)
+    )
+    df_bron_kvk = df_bron_kvk.drop(columns=["all_data"])
+
+    # add column Bronhouder, value is True when (​B) in kvk
+    df_bron_kvk["Bronhouder"] = False
+
+    bronhouder_pattern = r"[(​B)|(B)]"
+    df_bron_kvk.loc[
+        df_bron_kvk["KVK-nummer"].str.contains(bronhouder_pattern, regex=True),
+        "Bronhouder",
+    ] = True
+    # clean up kvk
+    df_bron_kvk["KVK-nummer"] = (
+        df_bron_kvk["KVK-nummer"]
+        .str.replace(bronhouder_pattern, "", regex=True)
+        .str.strip()
+    )
+
+    # remove leading and trailing whitespace from all columns
+    df_bron_kvk = df_bron_kvk.map(lambda x: x.strip() if isinstance(x, str) else x)
+
+    # make kvk index
+    df_bron_kvk.set_index("KVK-nummer", inplace=True)
+
+    return df_bron_kvk

--- a/brodata/bro.py
+++ b/brodata/bro.py
@@ -642,7 +642,7 @@ def get_brondocumenten_per_bronhouder(index=("kvk", "type"), timeout=5, **kwargs
     return df
 
 
-def dataframe_kvk(fn_bronhouder_kvk=None):
+def get_kvk_df(fn_bronhouder_kvk=None):
     """
     Read manually saved table of KVK and Organisatienaam to DataFrame.
 

--- a/brodata/data/bronhouder_kvk.txt
+++ b/brodata/data/bronhouder_kvk.txt
@@ -1,0 +1,686 @@
+# manually created by selecting rows on https://basisregistratieondergrond.nl/service-contact/formulieren/aangemeld-bro/
+# 28 august 2025 
+
+4Infra B.V. | 05084212
+Aannemingsbedrijf De Voogd Grijpskerke B.V. | 22050680
+Aannemersbedrijf van Wijlen B.V. | 18125438
+Aannemingsmaatschappij De Vries & Van de Wiel B.V. | 37061883
+Aannemingsmaatschappij Van Gelder B.V. | 08022082
+Aardwarmte Techniek Nederland B.V. | 82955123
+ABO-Milieuconsult B.V. | 22065838
+ABT B.V. | 09110804
+AbtWassenaar | 02037102
+Acacia Water B.V. | 2442829
+Adcim B.V. | 24313406
+Adviesbureau C.G.M. Schrijvers B.V. | 24316426
+Aelmans Eco B.V. | 14048216
+Aequator Groen & Ruimte B.V. | 09131961
+Afvalzorg Bodemservice B.V. |34091614
+AGEL adviseurs B.V. | 20051141
+Antea Nederland B.V. | 29021830
+APcon Adviesbureau B.V. | 55480209
+Aufko B.V. | 84250577
+Arcadis Nederland B.V. | 09036504
+Archimil B.V. | 17159750
+Artesia B.V. | 24318211
+ATKB B.V. | 27177140
+Avallo Advies | 52861724
+Avallo Advies BV | 82361185
+Aveco de Bondt  | 30169759
+Aw Infrabouw Bv | 28025419
+B.V. Aannemingsbedrijf De Klerk | 18109879
+Ballast Nedam Infra B.V. | 33154028
+Ballast Nedam Road Specialties B.V. | 70288623
+BAM Infra / Van den Herik Twentekanalen V.O.F. | 09073590
+BAM Infra B.V. | 24347782
+Bam Infraconsult B.V. | 09073590
+Badus Bodem en Water | 50638874
+Bedrijfsmilieudienst Flevoland B.V. | 39066679
+Beens Constructie Waterbouw B.V. | 05047611
+BIJ12 | 27261712
+Bioclear earth B.V. | 02044410
+BK Ingenieurs B.V. | 34082755
+Blik Sensing B.V. | 71730230
+BLM Wegenbouw B.V | 14622978
+BMA Milieu B.V. | 27240966
+Bodem Belang B.V. | 37078689
+Bodemvisie Milieu & Veiligheid B.V. | 58074201
+BOOT organiserend ingenieursburo B.V. | 30159072
+Boskalis Nederland B.V. | 24143025
+BoutenGeotron BV | 10039086
+Bouwconsults Nadema | 01064412
+Bouwontwerpburo Splatch B.V. | 34064993
+BouwRisk Inventarisatie & Management B.V. | 09149482
+Bouwservice Management Nederland B.V. | 20075240
+Brabant Water N.V. | 16005077 (​B)
+Buijs Hydro-Ecologisch Onderzoek & Advies|  02064655
+BUHA B.V. | 67288340
+Buro Antares B.V. | 24158873
+Buro Ontwerp en Omgeving | 09148203
+BV Ingenieursbureau Ir. K. Boorsma. | 01042375
+BVMS B.V. | 60211695
+BZ Ingenieurs en Managers B.V. | 08128785
+CinCera B.V. |17208323
+CRUX Engineering B.V. | 34171248
+C2engineers B.V. | 71987894
+CWG Ingenieurs b.v. | 67103375
+Combinatie A1 | A28 VOF  | 64199053
+Combinatie Dijkverbetering HOP | 61094803
+Combinatie MGZ v.o.f. | 72163399
+Combinatie SaVe v.o.f. | 71583440
+Combinatie STIPT V.O.F. | 76263851
+Compass Infrastructuur Nederland (CIN) B.V. | 50684442
+Coöperatie Bosgroep Midden Nederland U.A. | 09132872
+Daallin B.V. | 27263029
+DAGnl B.V. | 59459352
+DataScore Software B.V. | 17200060
+Dawaco BV | 88364321
+De Boer Advies & Uitvoering | 01088169
+De Groene Boog Construction V.O.F. | 71651128
+Den Hartog Geotechniek | 70117241
+De Vries & Van de Wiel Kust- en Oeverwerken B.V | 24450933
+De Vries Constructiebureau B.V. | 20094279
+DEME Infra Marine Contractors B.V. | 24277837
+Diseo B.V. | 54628490
+Dunea N.V. | 27122974 (​B)
+Dura Vermeer Infra Regionale Projecten B.V. | 34196257
+Dura Vermeer Bouw Zuid B.V. | 16061078
+Duwabo B.V. | 37104311
+DVA Engineering BV | 18076018
+Econsultancy B.V. | 13038286
+Eijkelkamp GeoPoint SoilSolutions B.V. | 70686149
+Eijkelkamp Soil & Water B.V. | 09043479
+EJA Services|73605816
+Energeo B.V. | 30192532
+Enviso B.V. | 01085113
+Evides N.V. | 24170650
+F.L. Liebregts B.V. | 18031929
+Fa. Gebr. van der Lee | 23045407
+FCC Construccion S.A.. | 76504972
+Fellinga Bouw en Installatie | 71221875
+FrieslandCampina Nederland B.V. | 01070163
+Fugro Innovation & Technology B.V. | 34048179
+Fugro NL Land B.V. | 27114147
+Gebroeders De Koning B.V. | 23041923
+GelreGroen Construction V.O.F. | 77546504
+Gemeenschappelijke regeling DCMR Milieudienst Rijnmond | 50000438
+Gemeenschappelijke regeling Omgevingsdienst Midden- en West-Brabant | 56679750
+Gemeenschappelijke regeling Regionale uitvoeringsdienst Zeeland | 58596313
+Gemeente 's-Hertogenbosch | 17278704 (​B)
+Gemeente Aa en Hunze | 01140749 (​B)
+Gemeente Aalsmeer | 34362237 (​B)
+Gemeente Aalten | 09215631 (​B)
+Gemeente Achtkarspelen | 01176356 (​B)
+Gemeente Alblasserdam | 51378469 (​B)
+Gemeente Albrandswaard | 50875825 (​B)
+Gemeente Alkmaar | 62255398 (​B)
+Gemeente Almelo | 08214858 (​B)
+Gemeente Almere | 32164984 (​B)
+Gemeente Alphen-Chaam | 50166727 (​B)
+Gemeente Alphen aan den Rijn | 27375186 (​B)
+Gemeente Altena | 73578886 (​B)
+Gemeente Ameland | 01180264 (​B)
+Gemeente Amersfoort | 32160938 (​B)
+Gemeente Amstelveen | 34365024 (​B)
+Gemeente Amsterdam | 34366966 (​B)
+Gemeente Apeldoorn | 08223882 (​B)
+Gemeente Appingedam | 01173706 (​B)
+Gemeente Arnhem | 09214908 (​B)
+Gemeente Assen | 50788590 (​B)
+Gemeente Asten | 50210254 (​B)
+Gemeente Baarle-Nassau | 20165117 (​B)
+Gemeente Baarn | 32167607 (​B)
+Gemeente Barendrecht | 24494374 (​B)
+Gemeente Barneveld | 50313851 (​B)
+Gemeente Bedum | 01173414 (B)
+Gemeente Beek | 50539728 (​B)
+Gemeente Beekdaelen | 73541532 (​B)
+Gemeente Beemster | 37160006 (​B)
+Gemeente Beesel | 14130743 (​B)
+Gemeente Berg en Dal | 62254944 (​B)
+Gemeente Bergen (L.) | 51350696 (​B)
+Gemeente Bergen (NH.) | 37159392 (​B)
+Gemeente Bergeijk | 17273202 (​B)
+Gemeente Berkelland | 09212462 (​B)
+Gemeente Bernheze | 50475266 (​B)
+Gemeente Bergen Op Zoom | 20169091 (​B)
+Gemeente Best | 17273055 (​B)
+Gemeente Beuningen | 51487659 (​B)
+Gemeente Beverwijk | 34379987 (​B)
+Gemeente Bladel | 17272566 (​B)
+Gemeente Blaricum | 32168837 (​B)
+Gemeente Bloemendaal | 34359304 (​B)
+Gemeente Bodegraven-Reeuwijk | 52505545 (​B)
+Gemeente Boekel | 17278721 (​B)
+Gemeente Borger-Odoorn | 50651072 (​B)
+Gemeente Borne | 50450948 (​B)
+Gemeente Borsele | 20164138 (​B)
+Gemeente Boxmeer | 50650068 (​B)
+Gemeente Boxtel | 17278580 (​B)
+Gemeente Breda | 20169706 (​B)
+Gemeente Brielle | 51392380 (​B)
+Gemeente Bronckhorst | 09218559 (​B)
+Gemeente Brummen | 50530003 (​B)
+Gemeente Brunssum | 14129999 (​B)
+Gemeente Bunnik | 30278213 (​B)
+Gemeente Bunschoten | 32165160 (​B)
+Gemeente Buren | 30278157 (​B)
+Gemeente Capelle aan den Ijssel | 51332493 (​B)
+Gemeente Castricum | 37158509 (​B)
+Gemeente Coevorden | 01173197 (​B)
+Gemeente Cranendonck | 17282376 (​B)
+Gemeente Culemborg | 30278756 (​B)
+Gemeente Dalfsen | 08215340 (​B)
+Gemeente Dantumadiel | 50820753 (​B)
+Gemeente De Bilt | 30286795 (​B)
+Gemeente De Fryske Marren | 59603925 (​B)
+Gemeente De Ronde Venen | 30282562 (​B)
+Gemeente De Wolden | 01160183 (​B)
+Gemeente Delft | 27374588 (​B)
+Gemeente Delfzijl | 01175851 (​B)
+Gemeente Den Haag | 27370927 (​B)
+Gemeente Den Helder | 37160613 (​B)
+Gemeente Deurne | 17281823 (​B)
+Gemeente Deventer | 08214418 (​B)
+Gemeente Diemen | 34374815 (​B)
+Gemeente Dijk en Waard | 85028827 (​B)
+Gemeente Dinkelland | 08226314 (​B)
+Gemeente Doesburg | 09222121 (​B)
+Gemeente Doetinchem | 09215668 (​B)
+Gemeente Dongen | 17274669 (​B)
+Gemeente Dordrecht | 50070525 (​B)
+Gemeente Drechterland | 37159718 (​B)
+Gemeente Drimmelen | 20164410 (​B)
+Gemeente Dronten | 32165460 (​B)
+Gemeente Druten | 30279480 (​B)
+Gemeente Duiven | 09217727 (​B)
+Gemeente Echt-Susteren | 51651866 (​B)
+Gemeente Edam-Volendam | 64973395 (​B)
+Gemeente Ede | 09215646 (​B)
+Gemeente Eemnes | 32170038 (​B)
+Gemeente Eemsdelta | 81425570 (​B)
+Gemeente Eersel | 17273265 (​B)
+Gemeente Elburg | 08218414 (​B)
+Gemeente Eindhoven | 17272738 (​B)
+Gemeente Eijsden-Margraten | 51643324 (​B)
+Gemeente Emmen | 01181973 (​B)
+Gemeente Enkhuizen | 37159077 (​B)
+Gemeente Enschede | 08215195 (​B)
+Gemeente Epe | 50483714 (​B)
+Gemeente Ermelo | 08217014 (​B)
+Gemeente Etten-Leur | 50601628 (​B)
+Gemeente Geertruidenberg | 50771752 (​B)
+Gemeente Geldrop-Mierlo | 17272524 (B)
+Gemeente Gemert-Bakel | 50371746 (B)
+Gemeente Gennep | 14131481 (B)
+Gemeente Gilze en Rijen | 17272741 (B)
+Gemeente Goeree-Overflakkee | 56710240 (​B)
+Gemeente Goes | 20164585 (​B)
+Gemeente Goirle | 17272690 (​B)
+Gemeente Gooise Meren | 64935345 (​B)
+Gemeente Gorinchem | 30280479 (​B)
+Gemeente Gouda | 24487063 (​B)
+Gemeente Grave | 17278466 (​B)
+Gemeente Groningen | 73558907 (​B)
+Gemeente Gulpen-Wittem | 50413872 (​B)
+Gemeente Haaksbergen | 50232274 (​B)
+Gemeente Haarlem | 34369366 (​B)
+Gemeente Haarlemmermeer | 73540374 (​B)
+Gemeente Halderberge | 20164480 (​B)
+Gemeente Hardenberg | 53009886 (​B)
+Gemeente Harderwijk | 50197576 (​B)
+Gemeente Hardinxveld-Giessendam | 51200570 (​B)
+Gemeente Harlingen | 50945149 (​B)
+Gemeente Hattem | 08217553 (​B)
+Gemeente Heemskerk | 34368749 (​B)
+Gemeente Heemstede | 34381346 (​B)
+Gemeente Heerde | 08213234 (​B)
+Gemeente Heerenveen | 59707720 (​B)
+Gemeente Heerlen | 14128451 (​B)
+Gemeente Heeze-Leende | 17274037 (​B)
+Gemeente Heiloo | 37159666 (​B)
+Gemeente Hellendoorn | 08221859 (​B)
+Gemeente Hellevoetsluis | 51860015 (​B)
+Gemeente Helmond | 17272669 (​B)
+Gemeente Hendrik-Ido-Ambacht | 24488714 (​B)
+Gemeente Hengelo | 08218146 (​B)
+Gemeente Heumen | 50916769 (​B)
+Gemeente Heusden | 17278565 (​B)
+Gemeente Hillegom | 27363838 (​B)
+Gemeente Hilvarenbeek | 17268742 (​B)
+Gemeente Hilversum | 32170443 (​B)
+Gemeente Het Hogeland | 73550728 (​B)
+Gemeente Hoeksche Waard | 73544086 (​B)
+Gemeente Hof van Twente | 08215304 (​B)
+Gemeente Hollands Kroon | 54477506 (​B)
+Gemeente Hoogeveen | 01175828 (​B)
+Gemeente Hoorn | 37159084 (​B)
+Gemeente Horst aan de Maas | 14130612 (​B)
+Gemeente Houten | 30279619 (​B)
+Gemeente Huizen | 32166112 (​B)
+Gemeente Hulst | 20165080 (​B)
+Gemeente IJsselstein | 30279625 (​B)
+Gemeente Kaag en Braassem | 27369098 (​B)
+Gemeente Kampen | 08216768 (​B)
+Gemeente Kapelle | 51309971 (​B)
+Gemeente Katwijk | 27370956 (​B)
+Gemeente Kerkrade | 50778692 (​B)
+Gemeente Koggenland | 50582445 (​B)
+Gemeente Krimpenerwaard | 62251686 (​B)
+Gemeente Krimpen aan den IJssel | 54596114 (​B)
+Gemeente Laarbeek | 17279582 (​B)
+Gemeente Landerd | 17275949 (​B)
+Gemeente Landgraaf | 14131528 (​B)
+Gemeente Landsmeer | 34363827 (​B)
+Gemeente Land van Cuijk | 85028037 (​B)
+Gemeente Lansingerland | 27366643 (​B)
+Gemeente Laren | 32169164 (​B)
+Gemeente Leeuwarden | 59734817 (​B)
+Gemeente Leiden | 27364192 (​B)
+Gemeente Leiderdorp | 27364127 (​B)
+Gemeente Leidschendam-Voorburg | 27370940 (​B)
+Gemeente Lelystad | 50000578 (​B)
+Gemeente Leudal | 50277324 (​B)
+Gemeente Leusden | 32167695 (​B)
+Gemeente Lingewaard | 50986767 (​B)
+Gemeente Lisse | 27370966 (​B)
+Gemeente Lochem | 08215192 (​B)
+Gemeente Loon op Zand | 17280777 (​B)
+Gemeente Lopik | 50029886 (​B)
+Gemeente Loppersum | 01180449 (​B)
+Gemeente Losser | 50869744 (​B)
+Gemeente Maasdriel | 30272405 (​B)
+Gemeente Maasgouw | 52925811 (​B)
+Gemeente Maashorst | 85031186 (​B)
+Gemeente Maassluis | 24484110 (​B)
+Gemeente Maastricht | 51488744 (​B)
+Gemeente Medemblik | 37159672 (​B)
+Gemeente Meerssen | 50443089 (​B)
+Gemeente Meierijstad | 66723019 (​B)
+Gemeente Meppel | 01178692 (​B)
+Gemeente Middelburg | 51041510 (​B)
+Gemeente Midden-Delfland | 27370601 (​B)
+Gemeente Midden-Drenthe | 01182848 (​B)
+Gemeente Midden-Groningen | 70476047 (​B)
+Gemeente Mill en Sint Hubert | 50466208 (​B)
+Gemeente Moerdijk | 20151657 (​B)
+Gemeente Molenlanden | 73552739 (​B)
+Gemeente Montferland | 09217772 (​B)
+Gemeente Montfoort | 30277195 (​B)
+Gemeente Mook en Middelaar | 09215819 (​B)
+Gemeente Neder-Betuwe | 30276311 (​B)
+Gemeente Nederweert | 52395413 (​B)
+Gemeente Neerijnen | 30280563 (B)
+Gemeente Nieuwegein | 30277029 (B)
+Gemeente Nieuwkoop | 27364328 (B)
+Gemeente Nijkerk | 32165156 (​B)
+Gemeente Nijmegen | 09220932 (​B)
+Gemeente Nissewaard | 62252046 (​B)
+Gemeente Noardeast-Fryslân | 73552496 (​B)
+Gemeente Noord-Beveland | 20164935 (​B)
+Gemeente Noordenveld | 01173391 (​B)
+Gemeente Noordoostpolder | 32170205 (​B)
+Gemeente Noordwijk | 73538469 (​B)
+Gemeente Nuenen c.a. | 17283654 (B)
+Gemeente Nunspeet | 52584372 (​B)
+Gemeente Oegstgeest | 50025929 (​B)
+Gemeente Oirschot | 17285344 (​B)
+Gemeente Oisterwijk | 17272760 (​B)
+Gemeente Oldambt | 01176290 (​B)
+Gemeente Oldebroek | 08223460 (​B)
+Gemeente Oldenzaal | 08224234 (​B)
+Gemeente Olst-Wijhe | 08222726 (​B)
+Gemeente Ommen | 51102757 (​B)
+Gemeente Oost Gelre | 09212525 (​B)
+Gemeente Oosterhout | 20164965 (​B)
+Gemeente Ooststellingwerf | 01180311 (​B)
+Gemeente Oostzaan | 34371033 (​B)
+Gemeente Opmeer | 37159195 (​B)
+Gemeente Opsterland | 01175380 (​B)
+Gemeente Oss | 50616641 (​B)
+Gemeente Oude-IJsselstreek | 09220971 (B)
+Gemeente Ouder-Amstel | 34359313 (B)
+Gemeente Oudewater | 53878388 (​B)
+Gemeente Overbetuwe | 51178567 (​B)
+Gemeente Papendrecht | 24483621 (​B)
+Gemeente Peel en Maas | 50397052 (​B)
+Gemeente Pekela | 50654993 (​B)
+Gemeente Pijnacker-Nootdorp | 27365912 (​B)
+Gemeente Purmerend | 37162503 (​B)
+Gemeente Putten | 08216960 (​B)
+Gemeente Raalte | 08215191 (​B)
+Gemeente Renkum | 09215649 (​B)
+Gemeente Reimerswaal | 51143313 (​B)
+Gemeente Renswoude | 32163726 (​B)
+Gemeente Reusel-De Mierden | 17272521 (​B)
+Gemeente Rheden | 52066169 (​B)
+Gemeente Rhenen | 30283218 (​B)
+Gemeente Ridderkerk | 24493197 (​B)
+Gemeente Rijssen-Holten | 50839519 (​B)
+Gemeente Rijswijk | 50681044 (​B)
+Gemeente Roerdalen | 50035452 (​B)
+Gemeente Roermond | 14117104 (​B)
+Gemeente Roosendaal | 20164788 (​B)
+Gemeente Rozendaal | 09214922 (​B)
+Gemeente Rotterdam | 24483298 (​B)
+Gemeente Rucphen | 20164997 (​B)
+Gemeente Schagen | 56838328 (​B)
+Gemeente Scherpenzeel | 32168248 (​B)
+Gemeente Schiedam | 50991663 (​B)
+Gemeente Schiermonnikoog | 01173331 (​B)
+Gemeente Schouwen-Duiveland | 20170062 (​B)
+Gemeente Simpelveld | 51486075 (​B)
+Gemeente Sint-Michielsgestel | 17237737 (​B)
+Gemeente Sint Anthonis | 17242249 (​B)
+Gemeente Sittard-Geleen | 14130475 (​B)
+Gemeente Sliedrecht | 24488726 (​B)
+Gemeente Sluis | 20164313 (​B)
+Gemeente Smallingerland | 01172164 (​B)
+Gemeente Soest | 32163787 (​B)
+Gemeente Someren | 17273152 (​B)
+Gemeente Son en Breugel | 17280818 (​B)
+Gemeente Stadskanaal | 01169424 (​B)
+Gemeente Staphorst | 50296140 (​B)
+Gemeente Stede Broec | 37159550 (​B)
+Gemeente Steenbergen | 20165025 (​B)
+Gemeente Steenwijkerland | 54137756 (​B)
+Gemeente Stein | 51984997 (​B)
+Gemeente Stichtse Vecht | 51681897 (​B)
+Gemeente Súdwest-Fryslân | 51791811 (​B)
+Gemeente Terneuzen | 20164929 (​B)
+Gemeente Terschelling | 01177508 (​B)
+Gemeente Texel | 37159104 (​B)
+Gemeente Teylingen | 27364167 (​B)
+Gemeente Tholen | 20166109 (​B)
+Gemeente Tiel | 30282147 (​B)
+Gemeente Tilburg | 17281808 (​B)
+Gemeente Tubbergen | 08215565 (​B)
+Gemeente Twenterand | 08215207 (​B)
+Gemeente Tynaarlo | 01169292 (​B)
+Gemeente Tytsjerksteradiel | 01169679 (​B)
+Gemeente Uden | 17279334 (​B)
+Gemeente Uitgeest | 34363838 (​B)
+Gemeente Uithoorn | 34371711 (​B)
+Gemeente Urk | 32166227 (​B)
+Gemeente Utrecht | 30280353 (​B)
+Gemeente Utrechtse Heuvelrug | 50092812 (​B)
+Gemeente Vaals | 14131922 (​B)
+Gemeente Valkenburg aan de Geul | 14131921 (​B)
+Gemeente Valkenswaard | 17272342 (​B)
+Gemeente Veendam | 50852736 (​B)
+Gemeente Veenendaal | 50182544 (​B)
+Gemeente Veere | 20165936 (​B)
+Gemeente Veldhoven | 17272483 (​B)
+Gemeente Velsen | 50115634 (​B)
+Gemeente Venlo | 14131668 (​B)
+Gemeente Venray | 14132389 (​B)
+Gemeente Vijfheerenlanden | 73547026 (​B)
+Gemeente Vlaardingen | 24485270 (​B)
+Gemeente Vlieland | 01181122 (​B)
+Gemeente Vlissingen | 20164548 (​B)
+Gemeente Voerendaal | 51896125 (​B)
+Gemeente Voorne aan Zee | 88738388 (​B)
+Gemeente Voorschoten | 27381083 (​B)
+Gemeente Voorst | 08218153 (​B)
+Gemeente Vught | 50653466 (​B)
+Gemeente Waadhoeke | 70528586 (​B)
+Gemeente Waalre | 17269410 (​B)
+Gemeente Waalwijk | 17278006 (​B)
+Gemeente Waddinxveen | 24482458 (​B)
+Gemeente Wageningen | 09216322 (​B)
+Gemeente Wassenaar | 27380612 (​B)
+Gemeente Waterland | 37158345 (​B)
+Gemeente Weert | 50320408 (​B)
+Gemeente Weesp | 32165235 (​B)
+Gemeente West Betuwe | 73549207 (​B)
+Gemeente West Maas en Waal | 30276854 (​B)
+Gemeente Westerkwartier | 73552208 (​B)
+Gemeente Westerveld | 01172480 (​B)
+Gemeente Westervoort | 09212509 (​B)
+Gemeente Westerwolde | 70485836 (​B)
+Gemeente Westland | 27371717 (​B)
+Gemeente Weststellingwerf | 50738631 (​B)
+Gemeente Westvoorne | 50358944 (​B)
+Gemeente Wierden | 53309561 (​B)
+Gemeente Wijchen | 09212602 (​B)
+Gemeente Wijdemeren | 32165063 (​B)
+Gemeente Wijk bij Duurstede | 30279669 (​B)
+Gemeente Winterswijk | 09219446 (​B)
+Gemeente Woensdrecht | 20164797 (​B)
+Gemeente Woerden | 50177214 (​B)
+Gemeente Woudenberg | 50676725 (​B)
+Gemeente Wormerland | 34371004 (​B)
+Gemeente Zaanstad | 34367942 (​B)
+Gemeente Zandvoort | 34363858 (​B)
+Gemeente Zaltbommel | 30276781 (​B)
+Gemeente Zeewolde | 32164515 (​B)
+Gemeente Zeist | 51626268 (​B)
+Gemeente Zevenaar | 71235426 (​B)
+Gemeente Zoetermeer | 27376002 (​B)
+Gemeente Zoeterwoude | 27363529 (​B)
+Gemeente Zuidhorn | 01182779 (B)
+Gemeente Zuidplas | 50595644 (​B)
+Gemeente Zundert | 51853876 (​B)
+Gemeente Zutphen | 50099604 (​B)
+Gemeente Zwartewaterland | 54552907 (​B)
+Gemeente Zwijndrecht | 24490491 (​B)
+Gemeente Zwolle | 08218173 (​B)
+GEO2 Engineering B.V. | 52849058
+Geo Infra B.V. | 20044878
+Geofoxx B.V. | 06056452
+Geonius Geotechniek B.V. | 14048726
+Geonius Milieu B.V. | 14048727
+GeoRisQ | 67574009
+Geomechanica B.V. | 37118604
+Geosonda B.V. | 27184822
+GKB Realisatie B.V | 24304985
+GOconnectIT B.V. | 30171797
+Grondboorbedrijf gebrs. Konings B.V. | 20018251
+Grondbooronderneming J. Hormann B.V. | 05033468
+Grondslag B.V. | 30101055
+GSNED B.V. | 61948888
+GWS-Data B.V. | 60832134
+Haasnoot Bruggen B.V. | 28049751
+Hakkers B.V. | 18114401
+HaskoningDHV Nederland B.V. | 56515154
+Havenbedrijf Rotterdam N.V. | 24354561
+HB Milieukundig en Civieltechnisch Adviesbureau B.V. | 34088102
+Heijmans Infra B.V. | 17104126
+Het gegevenshuis | 63720787
+Hektec B.V. | 36047459
+Hoogheemraadschap De Stichtse Rijnlanden | 30276831 (​B)
+Hoogheemraadschap Hollands Noorderkwartier | 37161516 (​B)
+Hoogheemraadschap van Delfland | 50677969 (​B)
+Hoogheemraadschap van Rijnland | 51137747 (​B)
+Hoogheemraadschap van Schieland en de Krimpenerwaard | 52213463 (​B)
+Hoogveld Sonderingen B.V. | 08145500
+Hutton Geo B.V. | 82359598
+I-Real B.V. | 09182897
+IDDS B.V. | 28047921
+Ifco Funderingsexpertise B.V. | 29032656
+IJB Geotechniek B.V. | 01059718
+IMD B.V. | 08109078
+Ingenieursbureau BT Geoconsult B.V. | 23087854
+Ingenieursbureau Krimpenerwaard | 17076128
+Ingenieursbureau Inpijn-Blokpoel Son B.V. | 17052457
+Ingenieursbureau Inpijn-Blokpoel West B.V. | 17076128
+Ingenieursbureau Land B.V. | 09122512
+Ingenieursbureau Maters en De Koning B.V. | 66346460
+IntellinQ B.V. | 59317833
+Inter Act B.V. | 08043827
+Inter Act industrial automation B.V. | 08103567
+InventerraComonServices B.V. | 24431723
+N.V. IRADO | 24304498
+IXAS Gaasperdammerweg B.V. | 61469696
+Jong Fruit B.V. | 17237480
+Kisters Nederland B.V. | 58545042
+Koenders & Partners adviseurs en procesmanagers B.V. | 30203750
+Koenders Instruments B.V. | 39064472
+Kooistra Agro Advies Bodem, Water en Bemesting | 57995656
+Koop Bronbemaling B.V. | 06070130
+Koops Grondmechanica B.V. | 61574031
+Kosterman milieutechniek B.V. | 30184349
+Kragten | 13021491
+Kruse Milieu B.V. | 06068751
+Kuipers Electronic Engineering B.V. | 23039023
+KWR Water B.V. | 27279653
+KWS Infra B.V. | 05062469
+KYL B.V. | 59327626
+Lankelma Adviesbureau B.V. | 54521610
+Lankelma Geotechniek Zuid B.V. | 17131641
+Lankelma Ingenieursbureau voor Geo Milieu en Funderingstechniek B.V. |  71979972
+LievenseCSO Milieu B.V. | 30152124
+Luinstra Watermanagement | 05052093
+LV Infra | 23089813
+LWRO | 17185598
+Martens en Van Oord Aannemingsbedrijf B.V. | 20050564
+Mateboer Milieu Techniek B.V. | 05051184
+Meerinzicht | 60325674 (​B)
+Meeuwisse Nederland B.V.| 27146962  MH Poly Consultants & Engineers B.V. | 24429486
+Megaborn Traffic Development BV | 11032897
+Milieu Advies Noord-Nederland | 73874817
+Milieutechniek ZVS Eemnes B.V. | 31034180
+Milieutechnisch Adviesbureau Heel BV | 13038100
+Miltop B.V. | 16078612
+MILON B.V. | 16066179
+Ministerie van Binnenlandse Zaken en   Koninkrijksrelaties | 50200097 (​B)
+Ministerie van Economische Zaken | 52813150 (​B)
+Ministerie van Infrastructuur en Milieu | 52766179 (​B)
+Ministerie van Klimaat en Groene Groei | 95206957 (​   B)
+Mobilis B.V. | 24289439
+Mos Grondmechanica B.V. | 24257098
+Mourik Limburg B.V. | 13017175
+Movares Nederland B.V. | 30124367
+MUG Ingenieursbureau B.V. | 02040355
+MuniSense B.V. | 27313745
+Nelen & Schuurmans B.V. | 30152280
+NH ingenieurs | 77312961
+N.V. Nederlandse Gasunie | 02029700
+N.V. Waterbedrijf Groningen | 02008621 (​B)
+N.V. PWN Waterleidingbedrijf Noord-Holland |   34072007 (​B)
+N.V. Waterleiding Maatschappij Limburg | 14602038 (​B)
+Nipa Milieutechniek B.V. | 16077486
+North Sea Port Netherlands N.V. | 50987496
+NU-adviesbureau | 22063981
+Oasen N.V. | 29010639 (​B)
+OBV C.V. | 32071273
+Océ-Technologies B.V. | 12002662
+Omgevingsdienst Brabant Noord | 54079403
+Omgevingsdienst Flevoland en Gooi en Vechtstreek |   55641857
+Omgevingsdienst Haaglanden | 56093926
+Omgevingsdienst IJmond | 51365901
+Omgevingsdienst Midden-Holland | 55366643
+Omgevingsdienst Zuid-Holland Zuid | 51291010
+Omgevingsdienst Omgevingsdienst Zuidoost-Brabant| 57159815
+Ortageo Nederland B.V. | 66382971
+P. Tilma | 36043614
+PJ Milieu B.V. | 32068654
+Poelsema Veldwerk B.V. | 05086972
+Prommenz Milieu B.V. | 73790370
+ProRail B.V. | 30124359 (​B)
+Provincie Drenthe | 01179514 (​B)
+Provincie Flevoland | 32164140 (​B)
+Provincie Fryslân | 01178978 (​B)
+Provincie Gelderland | 51468751 (​B)
+Provincie Groningen | 01182023 (​B)
+Provincie Limburg | 50052969 (​B)
+Provincie Noord-Brabant | 17278718 (​B)
+Provincie Noord-Holland | 34362354 (​B)
+Provincie Overijssel | 51048329 (​B)
+Provincie Utrecht | 30277172 (​B)
+Provincie Zeeland | 20168636 (​B)
+Provincie Zuid-Holland | 27375169 (​B)
+Raadgevend Ingenieursbureau Wiertsema & Partners   B.V. | 02095434
+Quattro-Expertise B.V. | 20122075
+RailTD B.V. | 66670861
+Rasenberg Infra B.V. | 20032947
+RB Geo B.V. | 62696696
+Real 4 U B.V. | 51713942
+Realworld Systems B.V. | 80495249
+Rijksdienst voor het Cultureel Erfgoed | 27367348 (​B)
+Rijksdienst voor Ondernemend Nederland |   27378529 (​B)
+Rijksinstituut voor Volksgezondheid en Milieu |   30276683 (​B)
+Rijksvastgoedbedrijf | 65890604 (​B)
+Rijkswaterstaat | 27364178 (​B)
+RHDHV Mijnbouw Delft B.V. | 81989261
+Royal Eijkelkamp | 09156795
+RPS Advies- en Ingenieursbureau B.V. | 24161143
+RPS Analyse B.V. | 20059540
+Sagro Milieu Advies Zeeland B.V. | 22038560
+Salverda Bouw B.V. | 08011909
+Sassevaart V.O.F. | 70281335
+Sas van Vreeswijk VOF | 65067096
+Sialtech B.V. | 30114487
+Silt Geo B.V. |17131641
+Smart Packaging Solutions B.V. | 02313313
+SPAT water | 83867341
+Spectrum HSE Technology | 68453507
+SPIE Nederland B.V. | 14635629
+SOCOTEC Geotechnics B.V. | 17068712
+Sondeer Techniek Nederland | 71752544
+Stantec | 27184323
+Stichting Deltares | 41146461
+Stichting Hogeschool van Arnhem en Nijmegen |   09091785
+Stichting ICTU | 27198742
+Stichting Wageningen Research | 09098104
+Stichting Waternet | 41216593 (​B)
+Strukton Infrastructure Specialties B.V. | 85008869
+Strukton Civiel Noord & Oost B.V. | 33056888
+Sweco Nederland B.V. | 30129769
+Syntrophos | 57304769
+Tauw B.V. | 38014985
+Tebezo Waterbouw & Nautische Dienstverlening B.V. |   05029571
+Terra Bodemonderzoek B.V. | 02062603
+Terra Practicus | 65031954
+TerraIndex B.V. | 27239531
+Terrascan B.V. | 34104282
+The Three Engineers B.V. | 08081725
+Timmermans Landmeetkunde B.V. | 01108276
+Tjaden Adviesbureau voor Grondmechanica B.V. |   54294959
+Tjaden B.V. | 34057287
+Trefoil Hydrology | 74503812
+Tritium Advies B.V. | 17108024
+TNO | 27376655
+VanderHelm Milieubeheer B.V. | 27233428
+Van den Herik Kust- en Oeverwerken B.V. | 23048358
+Van den Heuvel Aannemingsbedrijf B.V. | 16039823
+Van der Straaten Geotechniek | 20015504
+Van Essen Instruments B.V. | 27227624
+Van Harlingen Grondwater Management B.V. |   34182597
+Van Leeuwen Engineering & Automatisering |   91482720
+Van Oord Nederland | 18106742
+VCMI N.V. | 09128573
+veldapps.com | 50556649
+Verbelco B.V. | 09083617
+Vereniging tot Behoud van Natuurmonumenten in Nederland | 40516730
+Verhoeven Milieutechniek B.V. | 11028756
+Vervoort juridisch advies | 17249280
+Vissers-Ploegmakers B.V. | 16055402
+V.O.F Op de Akker | 53606507
+Van Dijk Geo- en Milieutechniek B.V. | 30128364
+Vitens N.V. | 05069581 (​B)
+VRM LevelLog B.V. | 66272688
+VWB Bodem B.V. | 62092758
+Wareco Ingenieurs | 33223543
+Waterlabs B.V. | 67965431
+Waterschap Aa en Maas | 17251019 (​B)
+Waterschap Amstel, Gooi en Vecht | 34360267 (​B)
+Waterschap Brabantse Delta | 51181584 (​B)
+Waterschap De Dommel | 17277734 (​B)
+Waterschap Drents Overijsselse Delta | 64208338 (​B)
+Waterschap Hollandse Delta | 52605825 (​B)
+Waterschap Hunze en Aa's | 01173230 (​B)
+Waterschap Limburg | 67682065 (​B)
+Waterschap Noorderzijlvest | 50130994 (​B)
+Waterschap Rijn en Ijssel | 09212548 (​B)
+Waterschap Rivierenland | 30281419 (​B)
+Waterschap Scheldestromen | 51640813 (​B)
+Waterschap Vallei en Veluwe | 56804636 (​B)
+Waterschap Vechtstromen | 58972676 (​B)
+Waterschap Zuiderzeeland | 32164084 (​B)
+Wetterskip Fryslân | 01174741 (​B)
+Wiha Grondmechanica | 52047202
+Witteveen+Bos Raadgevende ingenieurs B.V. |   38020751
+WMD Drinkwater B.V. | 67731910 (​B)
+WSP Nederland B.V. | 20045963
+Xaxis Technologies B.V. | 64931935

--- a/tests/test_bro.py
+++ b/tests/test_bro.py
@@ -222,3 +222,7 @@ def test_get_bhr_in_extent():
     colors = brodata.plot.lithology_colors.copy()
     colors["kleiigeHumus"] = colors["klei"]
     brodata.plot.lithology_along_line(gdf, line, "bro", colors=colors)
+
+
+def test_dataframe_kvk():
+    brodata.bro.dataframe_kvk()

--- a/tests/test_bro.py
+++ b/tests/test_bro.py
@@ -224,5 +224,5 @@ def test_get_bhr_in_extent():
     brodata.plot.lithology_along_line(gdf, line, "bro", colors=colors)
 
 
-def test_dataframe_kvk():
-    brodata.bro.dataframe_kvk()
+def test_get_kvk_df():
+    brodata.bro.get_kvk_df()


### PR DESCRIPTION
Based on comment from @HMEUW in issue #23, with some minor changes:
- edited column names in the resulting dataframe so they are equal to the original source: https://basisregistratieondergrond.nl/service-contact/formulieren/aangemeld-bro/
- removed leading spaces from bronhouder_kvk.txt
- renamed method from `dataframe_kvk` to `get_kvk_df`

The implementation in other methods in brodata will maybe be added in the future.