### PR TITLE
Add and apply `_get_main_object`

### DIFF
--- a/brodata/bhr.py
+++ b/brodata/bhr.py
@@ -24,10 +24,7 @@ class _BoreholeResearch(bro.FileOrUrl):
             "bhrgtcom": "http://www.broservices.nl/xsd/bhrgtcommon/2.1",
             "xmlns": self._xmlns,
         }
-        bhrs = tree.findall(f".//xmlns:{self._object_name}", ns)
-        if len(bhrs) != 1:
-            raise (Exception(f"Only one {self._object_name} supported"))
-        bhr = bhrs[0]
+        bhr = self._get_main_object(tree, self._object_name, ns)
         for key in bhr.attrib:
             setattr(self, key.split("}", 1)[1], bhr.attrib[key])
         for child in bhr:

--- a/brodata/bro.py
+++ b/brodata/bro.py
@@ -612,6 +612,24 @@ class FileOrUrl(ABC):
     def _get_tag(node):
         return util._get_tag(node)
 
+    def _get_main_object(self, tree, object_name=None, ns=None):
+        if object_name is None:
+            object_name = self._object_name
+        if ns is None:
+            ns = {"xmlns": self._xmlns}
+        if isinstance(object_name, list):
+            for name in object_name:
+                objects = tree.findall(f".//xmlns:{name}", ns)
+                if objects:
+                    break
+        else:
+            objects = tree.findall(f".//xmlns:{object_name}", ns)
+        if len(objects) > 1:
+            raise (Exception(f"Only one {object_name} supported"))
+        elif len(objects) == 0:
+            raise (Exception(f"No {object_name} found"))
+        return objects[0]
+
     def _warn_unknown_tag(self, tag, parent=None):
         class_name = self.__class__.__name__
         bro_id = getattr(self, "broId", "")

--- a/brodata/cpt.py
+++ b/brodata/cpt.py
@@ -25,12 +25,7 @@ class ConePenetrationTest(bro.FileOrUrl):
             "cptcommon": "http://www.broservices.nl/xsd/cptcommon/1.1",
             "xmlns": self._xmlns,
         }
-        cpts = tree.findall(".//xmlns:CPT_O", ns)
-        if len(cpts) > 1:
-            raise (Exception("Only one CPT_0 supported"))
-        elif len(cpts) == 0:
-            raise (Exception("No CPT_0 found"))
-        cpt = cpts[0]
+        cpt = self._get_main_object(tree, "CPT_0", ns)
         for key in cpt.attrib:
             setattr(self, key.split("}", 1)[1], cpt.attrib[key])
         for child in cpt:

--- a/brodata/cpt.py
+++ b/brodata/cpt.py
@@ -25,7 +25,7 @@ class ConePenetrationTest(bro.FileOrUrl):
             "cptcommon": "http://www.broservices.nl/xsd/cptcommon/1.1",
             "xmlns": self._xmlns,
         }
-        cpt = self._get_main_object(tree, "CPT_0", ns)
+        cpt = self._get_main_object(tree, "CPT_O", ns)
         for key in cpt.attrib:
             setattr(self, key.split("}", 1)[1], cpt.attrib[key])
         for child in cpt:
@@ -91,7 +91,6 @@ class ConePenetrationTest(bro.FileOrUrl):
                 self._read_children_of_children(child)
             elif key in ["cptResult", "disResult"]:
                 setattr(self, name, self._read_data_array(child))
-                
             else:
                 self._warn_unknown_tag(key)
 

--- a/brodata/epc.py
+++ b/brodata/epc.py
@@ -23,17 +23,9 @@ class ExplorationProductionConstruction(bro.FileOrUrl):
             "xmlns": self._xmlns,
         }
 
-        # Try to find EPC_PO_Borehole or EPC_PO_DP_Borehole
-        epcs = tree.findall(".//xmlns:EPC_PO_Borehole", ns)
-        if not epcs:
-            epcs = tree.findall(".//xmlns:EPC_PO_DP_Borehole", ns)
-        if not epcs:
-            epcs = tree.findall(".//xmlns:EPC_PPO_Borehole", ns)
-
-        if len(epcs) != 1:
-            raise Exception(f"Expected 1 EPC object, found {len(epcs)}")
-
-        epc = epcs[0]
+        # Try to find EPC_PO_Borehole, EPC_PO_DP_Borehole or EPC_PPO_Borehole
+        object_names = ["EPC_PO_Borehole", "EPC_PO_DP_Borehole", "EPC_PPO_Borehole"]
+        epc = self._get_main_object(tree, object_names, ns)
 
         # Parse attributes
         for key in epc.attrib:

--- a/brodata/gar.py
+++ b/brodata/gar.py
@@ -45,10 +45,7 @@ class GroundwaterAnalysisReport(bro.FileOrUrl):
             "garcommon": "http://www.broservices.nl/xsd/garcommon/1.0",
             "xmlns": self._xmlns,
         }
-        gars = tree.findall(".//xmlns:GAR_O", ns)
-        if len(gars) != 1:
-            raise (Exception("Only one GAR_O supported"))
-        gar = gars[0]
+        gar = self._get_main_object(tree, "GAR_O", ns)
         for key in gar.attrib:
             setattr(self, key.split("}", 1)[1], gar.attrib[key])
         for child in gar:

--- a/brodata/gld.py
+++ b/brodata/gld.py
@@ -342,10 +342,7 @@ class GroundwaterLevelDossier(bro.FileOrUrl):
             "om": "http://www.opengis.net/om/2.0",
             "xlink": "http://www.w3.org/1999/xlink",
         }
-        glds = tree.findall(".//ns11:GLD_O", ns)
-        if len(glds) != 1:
-            raise (Exception("Only one gld supported"))
-        gld = glds[0]
+        gld = self._get_main_object(tree, "GLD_O", ns)
         for key in gld.attrib:
             setattr(self, key.split("}", 1)[1], gld.attrib[key])
         for child in gld:

--- a/brodata/gld.py
+++ b/brodata/gld.py
@@ -335,7 +335,7 @@ class GroundwaterLevelDossier(bro.FileOrUrl):
         accessed as a DataFrame.
         """
         ns = {
-            "ns11": "http://www.broservices.nl/xsd/dsgld/1.0",
+            "xmlns": "http://www.broservices.nl/xsd/dsgld/1.0",
             "gldcommon": "http://www.broservices.nl/xsd/gldcommon/1.0",
             "waterml": "http://www.opengis.net/waterml/2.0",
             "swe": "http://www.opengis.net/swe/2.0",

--- a/brodata/gmn.py
+++ b/brodata/gmn.py
@@ -21,10 +21,7 @@ class GroundwaterMonitoringNetwork(bro.FileOrUrl):
             "gmncom": "http://www.broservices.nl/xsd/gmncommon/1.0",
             "xmlns": self._xmlns,
         }
-        gmns = tree.findall(".//xmlns:GMN_PO", ns)
-        if len(gmns) != 1:
-            raise (Exception("Only one GMN_PO supported"))
-        gmn = gmns[0]
+        gmn = self._get_main_object(tree, "GMN_PO", ns)
         for key in gmn.attrib:
             setattr(self, key.split("}", 1)[1], gmn.attrib[key])
         for child in gmn:

--- a/brodata/gmw.py
+++ b/brodata/gmw.py
@@ -65,16 +65,8 @@ class GroundwaterMonitoringWell(bro.FileOrUrl):
             "xmlns": self._xmlns,
         }
 
-        gmws = tree.findall(".//xmlns:GMW_PO", ns)
-        if len(gmws) == 0:
-            gmws = tree.findall(".//xmlns:GMW_PPO", ns)
-        if len(gmws) == 0:
-            gmws = tree.findall(".//brocom:BRO_DO", ns)
-        if len(gmws) == 0:
-            raise (ValueError("No gmw found"))
-        elif len(gmws) > 1:
-            raise (Exception("Only one gmw supported"))
-        gmw = gmws[0]
+        object_names = ["GMW_PO", "GMW_PPO", "BRO_DO"]
+        gmw = self._get_main_object(tree, object_names, ns)
 
         for key in gmw.attrib:
             setattr(self, key.split("}", 1)[1], gmw.attrib[key])

--- a/brodata/gpd.py
+++ b/brodata/gpd.py
@@ -19,13 +19,7 @@ class GroundwaterProductionDossier(bro.FileOrUrl):
             "xmlns": self._xmlns,
         }
 
-        gpds = tree.findall(".//xmlns:GPD_O", ns)
-
-        if len(gpds) == 0:
-            raise (ValueError("No gpd found"))
-        elif len(gpds) > 1:
-            raise (Exception("Only one gpd supported"))
-        gpd = gpds[0]
+        gpd = self._get_main_object(tree, "GPD_O", ns)
 
         for key in gpd.attrib:
             setattr(self, key.split("}", 1)[1], gpd.attrib[key])

--- a/brodata/guf.py
+++ b/brodata/guf.py
@@ -35,12 +35,7 @@ class GroundwaterUtilisationFacility(bro.FileOrUrl):
 
     def _read_contents(self, tree):
         ns = self._namespace
-        gufs = tree.findall(".//xmlns:GUF_PO", ns)
-        if len(gufs) == 0:
-            gufs = tree.findall(".//xmlns:GUF_PPO", ns)
-        if len(gufs) != 1:
-            raise (Exception("Only one GUF_PO supported"))
-        guf = gufs[0]
+        guf = self._get_main_object(tree, ["GUF_PO", "GUF_PPO"], ns)
         for key in guf.attrib:
             setattr(self, key.split("}", 1)[1], guf.attrib[key])
         for child in guf:

--- a/brodata/sad.py
+++ b/brodata/sad.py
@@ -13,15 +13,13 @@ class SiteAssessmentData(bro.FileOrUrl):
 
     def _read_contents(self, tree):
         ns = {
-        "brocom": "http://www.broservices.nl/xsd/brocommon/3.0",
-        "gml": "http://www.opengis.net/gml/3.2",
-        "sadcommon": "http://www.broservices.nl/xsd/sadcommon-internal/1.1",
-        "xmlns": self._xmlns,
-    }
-        sads = tree.findall(".//xmlns:SAD_O", ns)
-        if len(sads) != 1:
-            raise (Exception("Only one SAD_O supported"))
-        sad = sads[0]
+            "brocom": "http://www.broservices.nl/xsd/brocommon/3.0",
+            "gml": "http://www.opengis.net/gml/3.2",
+            "sadcommon": "http://www.broservices.nl/xsd/sadcommon-internal/1.1",
+            "xmlns": self._xmlns,
+        }
+        sad = self._get_main_object(tree, "SAD_O", ns)
+
         for key in sad.attrib:
             setattr(self, key.split("}", 1)[1], sad.attrib[key])
         for child in sad:
@@ -36,7 +34,7 @@ class SiteAssessmentData(bro.FileOrUrl):
                 self._read_standardized_location(child)
             elif key == "report":
                 if hasattr(self, key):
-                    self._raise_assumed_single()
+                    self._raise_assumed_single(key)
                 self.report = {}
                 self._read_children_of_children(child, d=self.report)
             elif key == "measurementPoint":

--- a/brodata/sfr.py
+++ b/brodata/sfr.py
@@ -26,10 +26,7 @@ class SoilFaceResearch(bro.FileOrUrl):
             "sfrcom": "http://www.broservices.nl/xsd/sfrcommon/2.0",
             "xmlns": self._xmlns,
         }
-        sfrs = tree.findall(".//xmlns:SFR_O", ns)
-        if len(sfrs) != 1:
-            raise (Exception("Only one SFR_O supported"))
-        sfr = sfrs[0]
+        sfr = self._get_main_object(tree, "SFR_O", ns)
         for key in sfr.attrib:
             setattr(self, key.split("}", 1)[1], sfr.attrib[key])
         for child in sfr:


### PR DESCRIPTION
Inspired by issue #42:

* Introduced the `_get_main_object` helper method in `bro.py` to encapsulate the logic for finding the main XML object(s) by tag name(s), including error handling for missing or multiple objects.
* Updated all `_read_contents` methods in modules such as `bhr.py`, `cpt.py`, `epc.py`, `gar.py`, `gld.py`, `gmn.py`, `gmw.py`, `gpd.py`, `guf.py`, `sad.py`, and `sfr.py` to use the new `_get_main_object` method instead of duplicating the XML search and validation logic. [[1]](diffhunk://#diff-cfc6964e676eccb8eb42273b8ac197fbea1ae8729bca63cec2e24cc27a10a762L27-R27) [[2]](diffhunk://#diff-7962c71faf2d2e8c8807dfe2073d690fa595099cd089b39c27b4303cac2dc38dL28-R28) [[3]](diffhunk://#diff-5f5c62375415e3a0686077399ce2d80661399f2664571e248845bb25ad3cb36bL26-R28) [[4]](diffhunk://#diff-0f7cf97ce8e601353f482622809a66989f970f9304da4356556dde431c9c613bL48-R48) [[5]](diffhunk://#diff-0af34b1a260f42db70eb1019c7ca9b6fc41ac98a36523332a9dd84f300ebf820L345-R345) [[6]](diffhunk://#diff-4bc37c782271321244514a0b507350bd796df6aba3c6a57773efa1e61001ef4fL24-R24) [[7]](diffhunk://#diff-80747a6cadc94a08f2d0317226d137e0ce6fad8c54647a74ef8bacd480924ef2L68-R69) [[8]](diffhunk://#diff-be0bcfe00b5bb6123ade83a840bba8339bfefbe830c69ac4adad9ee9fbdfa53aL22-R22) [[9]](diffhunk://#diff-0555db82538394f8e91fed10612fe2edd051559ae518bdf41103fc7c76ef2d8aL38-R38) [[10]](diffhunk://#diff-d0b4dd33b93a001740b5b1a3e370d5f39d02913c6c4337c97fc50ac6d9eee77eL21-R22) [[11]](diffhunk://#diff-5ba777335b14989e4807decd9c0165770df6bdf00cb9f5440585a4557bc3b5ffL29-R29)

Error handling improvements:

* Enhanced error messages and consistency for cases where the expected XML object is missing or duplicated, as all modules now rely on the centralized error handling in `_get_main_object`.

Minor bug fix:

* Fixed a call to `_raise_assumed_single` in `sad.py` to correctly pass the key parameter.