### PR TITLE
Add new lithology colors

### DIFF
--- a/brodata/plot.py
+++ b/brodata/plot.py
@@ -121,6 +121,7 @@ def cone_penetration_test(
 
 lithology_colors = {
     "ballast": (200 / 255, 200 / 255, 200 / 255),  # checked at B38D4055
+    "baggert": (144 / 255, 144 / 255, 144 / 255),  # checked at B60C5217 
     "bruinkool": (140 / 255, 92 / 255, 54 / 255),  # checked at B51G2426
     "detritus": (157 / 255, 78 / 255, 64 / 255),  # checked at B44A0733
     "glauconietzand": (204 / 255, 1, 153 / 255),  # checked at B49E1446
@@ -130,10 +131,13 @@ lithology_colors = {
     "kalksteen": (140 / 255, 180 / 255, 1),  # checked at B44B0062
     "klei": (0, 146 / 255, 0),
     "leem": (194 / 255, 207 / 255, 92 / 255),
+    "mergel ": (140 / 255, 180 / 255, 255 / 255), # checked at B60C0656 
+    "mijnsteen": (200 / 255, 200 / 255, 200 / 255), # checked at B60C3651
     "oer": (200 / 255, 200 / 255, 200 / 255),
     "puin": (200 / 255, 200 / 255, 200 / 255),
     "slurrie": (144 / 255, 144 / 255, 144 / 255),  # same as slib, checked at B25A3512
     "stenen": (216 / 255, 163 / 255, 32 / 255),
+    "stigmaria": (144 / 255, 144 / 255, 144 / 255), # same as baggert , checked at B60C5003 
     "veen": (157 / 255, 78 / 255, 64 / 255),
     "zand": (1, 1, 0),
     "zand fijn": (1, 1, 0),  # same as zand
@@ -141,12 +145,15 @@ lithology_colors = {
     "zand grof": (231 / 255, 195 / 255, 22 / 255),
     "sideriet": (242 / 255, 128 / 255, 13 / 255),  # checked at B51D2864
     "slib": (144 / 255, 144 / 255, 144 / 255),
+    "schalie": (156 / 255, 158 / 255, 99 / 255), # checked at B60C4442
     "schelpen": (95 / 255, 95 / 255, 1),
     "sterkGrindigZand": (
         231 / 255,
         195 / 255,
         22 / 255,
     ),  # same as zand grove categorie
+    "steenkool": (58 / 255, 37 / 255, 22 / 255), # checked at B60C4442  
+    "vast gesteente": (97 / 255, 97 / 255, 97 / 255), # checked at B60C5112 
     "wegverhardingsmateriaal": (
         200 / 255,
         200 / 255,

--- a/brodata/plot.py
+++ b/brodata/plot.py
@@ -122,6 +122,8 @@ def cone_penetration_test(
 lithology_colors = {
     "ballast": (200 / 255, 200 / 255, 200 / 255),  # checked at B38D4055
     "baggert": (144 / 255, 144 / 255, 144 / 255),  # checked at B60C5217 
+    "baksteen": (200 / 255, 200 / 255, 200 / 255),  # checked at B31H2923 
+    "beton": (200 / 255, 200 / 255, 200 / 255),  # same as baksteen, checked at B31H2925     
     "bruinkool": (140 / 255, 92 / 255, 54 / 255),  # checked at B51G2426
     "detritus": (157 / 255, 78 / 255, 64 / 255),  # checked at B44A0733
     "glauconietzand": (204 / 255, 1, 153 / 255),  # checked at B49E1446
@@ -131,10 +133,11 @@ lithology_colors = {
     "kalksteen": (140 / 255, 180 / 255, 1),  # checked at B44B0062
     "klei": (0, 146 / 255, 0),
     "leem": (194 / 255, 207 / 255, 92 / 255),
-    "mergel ": (140 / 255, 180 / 255, 255 / 255), # checked at B60C0656 
+    "mergel ": (140 / 255, 180 / 255, 1), # checked at B60C0656 
     "mijnsteen": (200 / 255, 200 / 255, 200 / 255), # checked at B60C3651
+    "moeraskalk": (204 / 255, 102 / 255, 1), # checked at B31D1237
     "oer": (200 / 255, 200 / 255, 200 / 255),
-    "puin": (200 / 255, 200 / 255, 200 / 255),
+    "puin": (200 / 255, 200 / 255, 200 / 255), # same as beton
     "slurrie": (144 / 255, 144 / 255, 144 / 255),  # same as slib, checked at B25A3512
     "stenen": (216 / 255, 163 / 255, 32 / 255),
     "stigmaria": (144 / 255, 144 / 255, 144 / 255), # same as baggert , checked at B60C5003 


### PR DESCRIPTION
Missing lithology colors in Limburg, have been added. RGB values found with the inspect element tool on the dino SVG's

Vast Gesteente, B60C5112 rgb(97, 97, 97)
Schalie, B60C4442, rgb(156, 158, 99)
Steenkool, B60C4442, rgb(58, 37, 22)
baggert, B60C5217, rgb(144,144,144)
mijnsteen, B60C3651, rgb(200,200,200)
stigmaria, B60C5003, rgb(144,144,144)
mergel, B60C0656, rgb(140,180,255)
