### PR TITLE
Fix add_observations_to_tubes return value

### DIFF
--- a/brodata/gmw.py
+++ b/brodata/gmw.py
@@ -800,6 +800,7 @@ def add_observations_to_tubes(gdf, obs_df, kind="gld"):
         ids[index] = list(obs_df.loc[[index], "broId"])
     gdf[datcol] = data
     gdf[idcol] = ids
+    return gdf
 
 
 def _get_data_column(kind):

--- a/tests/test_gmw.py
+++ b/tests/test_gmw.py
@@ -61,6 +61,28 @@ def test_gmw_get_gar_data_in_extent():
     brodata.gmw.get_data_in_extent(extent=extent, kind="gar", combine=True)
 
 
+def test_add_observations_to_tubes_returns_updated_dataframe():
+    index = pd.MultiIndex.from_tuples(
+        [("GMW000000000001", 1)],
+        names=["groundwaterMonitoringWell", "tubeNumber"],
+    )
+    tubes = pd.DataFrame(index=index)
+    observations = pd.DataFrame(
+        {
+            "broId": ["GAR000000000001"],
+            "laboratoryAnalysis": [pd.DataFrame({"value": [1.0]})],
+        },
+        index=index,
+    )
+
+    result = brodata.gmw.add_observations_to_tubes(tubes, observations, kind="gar")
+
+    assert result is tubes
+    assert result.at[("GMW000000000001", 1), "groundwaterAnalysisReport"] == [
+        "GAR000000000001"
+    ]
+
+
 # def test_gmw_get_frd_data_in_extent():
 #    extent = [115000, 120000, 438000, 441000]
 #    gdf, frd = brodata.gmw.get_data_in_extent(extent=extent, kind="frd")


### PR DESCRIPTION
## Summary
- return the updated dataframe from `add_observations_to_tubes()`
- add a small regression test for the helper return value

## Verification
- `PYTHONPATH=. uv run --python 3.12 --with '.[ci]' pytest tests/test_gmw.py -q`\n- `PYTHONPATH=. uv run --python 3.12 --with '.[ci]' pytest tests/test_gmw.py::test_gmw_get_gld_data_in_extent_as_csv -q`\n- `PYTHONPATH=. uv run --python 3.12 --with '.[ci]' python -m compileall -q brodata tests`\n- `PYTHONPATH=. uv run --python 3.12 --with ruff ruff check brodata/gmw.py tests/test_gmw.py`\n- `PYTHONPATH=. uv run --python 3.12 --with ruff ruff format --check brodata/gmw.py tests/test_gmw.py`\n\nFull `pytest ./tests -q` reached 66 passed / 2 skipped, then failed on three live-service requests to `www.broloket.nl` / `publiek.broservices.nl`, unrelated to this change.\n\nAI assistance was used under my direction.